### PR TITLE
fix: correct critical typo in README - Changed 'implimentation' to 'implementation'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-This document describes the implimentation details of MedVerify project.
+This document describes the implementation details of MedVerify project.


### PR DESCRIPTION
This was causing confusion for users.
